### PR TITLE
Adding labels for OpenShift GitOps controller

### DIFF
--- a/apps/bgd/overlays/bgd/bgd-ns.yaml
+++ b/apps/bgd/overlays/bgd/bgd-ns.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: bgd
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops 
+    argocd.argoproj.io/managed-by: openshift-gitops
+     

--- a/apps/bgd/overlays/bgd/bgd-ns.yaml
+++ b/apps/bgd/overlays/bgd/bgd-ns.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: bgd
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops 

--- a/apps/bgd/overlays/bgdk/bgdk-ns.yaml
+++ b/apps/bgd/overlays/bgdk/bgdk-ns.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: bgdk
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops

--- a/apps/bgd/overlays/bgdk/bgdk-ns.yaml
+++ b/apps/bgd/overlays/bgdk/bgdk-ns.yaml
@@ -4,3 +4,4 @@ metadata:
   name: bgdk
   labels:
     argocd.argoproj.io/managed-by: openshift-gitops
+    

--- a/apps/welcome-php/overlays/hooks/welcome-php-ns.yaml
+++ b/apps/welcome-php/overlays/hooks/welcome-php-ns.yaml
@@ -4,5 +4,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
   name: welcome-hooks
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
 spec: {}
 status: {}

--- a/apps/welcome-php/overlays/syncwaves-and-hooks/welcome-php-ns.yaml
+++ b/apps/welcome-php/overlays/syncwaves-and-hooks/welcome-php-ns.yaml
@@ -5,5 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
   name: welcome-waves-and-hooks
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
 spec: {}
 status: {}

--- a/apps/welcome-php/overlays/syncwaves/welcome-php-ns.yaml
+++ b/apps/welcome-php/overlays/syncwaves/welcome-php-ns.yaml
@@ -5,5 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
   name: welcome
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
 spec: {}
 status: {}


### PR DESCRIPTION
Adding labels for OpenShift GitOps controller to be able to manage resources in non-`OpenShift-Gitops` namespaces.