### PR TITLE
add TLS support for bgd-route.yaml

### DIFF
--- a/apps/bgd/overlays/bgd/bgd-route.yaml
+++ b/apps/bgd/overlays/bgd/bgd-route.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   port:
     targetPort: 8080
+  tls: 
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge    
   to:
     kind: Service
     name: bgd


### PR DESCRIPTION
This change is for instruqt, not sure if it will break other demos.
See: https://www.redhat.com/en/interactive-labs/get-started-argo-cd-gitops-red-hat-openshift